### PR TITLE
Correction du lien de clonage du repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ renforcer leurs compétences en programmation Java.
 ## Utilisation
 1. Cloner ce dépôt localement sur votre machine :
    ```
-   git clone https://github.com/votre-utilisateur/nom-du-depot.git
+   git clone https://github.com/ETS-Winter-2024-CUT/INF111-Exemples_Java.git
    ```
 2. Utiliser un IDE tel que Visual Studio Code, Eclipse, IntelliJ ou tout autre éditeur de code Java.
 3. Les exemples de code se trouvent dans le répertoire "src".


### PR DESCRIPTION
## Description de la Pull Request

### Description brève des modifications

Cette Pull Request vise à mettre à jour les instructions d'utilisation du dépôt pour le cours INF111.

### Détail des modifications

- Remplacement de l'URL du dépôt pour correspondre à `https://github.com/ETS-Winter-2024-CUT/INF111-Exemples_Java.git`.

### Objectif des modifications/Problème résolu (le cas échéant)

Ces modifications sont essentielles pour diriger les utilisateurs vers le bon dépôt du cours INF111. Cela corrige l'URL de clonage du dépôt mentionné dans les instructions, assurant ainsi que les utilisateurs accèdent au bon référentiel pour les exemples de code Java.

### Captures d'écran (le cas échéant)

*Aucune capture d'écran nécessaire pour ces modifications.*

### Étapes de vérification

1. Cloner le dépôt localement en utilisant la commande : `git clone https://github.com/ETS-Winter-2024-CUT/INF111-Exemples_Java.git`.
2. Vérifier que les modifications ont correctement mis à jour l'URL du dépôt dans les instructions d'utilisation.
3. S'assurer que les exemples de code se trouvent toujours dans le répertoire "src".

### Notes pour le relecteur

*Aucune note spécifique pour le moment.*